### PR TITLE
Fix exceeding batch recursion limit

### DIFF
--- a/alwsl.bat
+++ b/alwsl.bat
@@ -319,7 +319,7 @@ goto :eof
 
 :waitforexit
 if exist "%localappdata%\lxss\temp" (
-	call :waitforexit
+	goto :waitforexit
 )
 goto :eof
 


### PR DESCRIPTION
When I was trying to install ALWSL, I've been getting `batch recursion limit exceeded` on each try. This change has fixed the problem.